### PR TITLE
Fix missing form tag closure in FormularioSolicitud

### DIFF
--- a/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
+++ b/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
@@ -10,6 +10,7 @@
   <form
     [formGroup]="formulario"
     (ngSubmit)="guardar()"
+  >
     <!-- Nombre del Solicitante -->
     <div class="mb-3">
       <label class="form-label">Nombre Solicitante</label>


### PR DESCRIPTION
## Summary
- close the opening form tag

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841059d8574832693de5dde7c0df65b