### PR TITLE
Fix API calls via proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ This project was generated using [Angular CLI](https://github.com/angular/angula
 
 ## Development server
 
-To start a local development server, run:
+To start a local development server with the proxy enabled, run:
 
 ```bash
 ng serve
 ```
 
-Once the server is running, open your browser and navigate to `http://localhost:4200/`. The application will automatically reload whenever you modify any of the source files.
+Once the server is running, open your browser and navigate to `http://localhost:4200/`.
+API requests will be proxied to `http://localhost:8080` thanks to `proxy.conf.json`, so no extra configuration is required.
+The application will automatically reload whenever you modify any of the source files.
 
 ## Code scaffolding
 

--- a/src/app/services/solicitudes-aduana/solicitud-aduana.ts
+++ b/src/app/services/solicitudes-aduana/solicitud-aduana.ts
@@ -8,7 +8,15 @@ import { SolicitudAduana } from '../../models/solicitud-aduana';
 @Injectable({ providedIn: 'root' })
 export class SolicitudAduanaService {
 
-  private readonly baseUrl = 'http://localhost:8080/api/solicitudes';
+  /**
+   * Base URL para las solicitudes de la API.
+   *
+   * Se deja relativa para aprovechar el proxy de desarrollo
+   * (proxy.conf.json) y evitar problemas de CORS en entornos
+   * locales. Cuando se despliegue a producción puede apuntar a la
+   * URL absoluta correspondiente.
+   */
+  private readonly baseUrl = '/api/solicitudes';
 
   constructor(private http: HttpClient) {}
 


### PR DESCRIPTION
## Summary
- use a relative URL for `SolicitudAduanaService` so requests go through the Angular dev proxy
- document proxy usage in README

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68410a08202083269509dee1e2a5d95c