### PR TITLE
Fix missing tipoAdjunto parameter

### DIFF
--- a/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
+++ b/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
@@ -101,10 +101,10 @@
     <!-- Tipo de Documento Adjunto -->
     <div class="mb-3">
       <label class="form-label">Tipo Documento Adjunto</label>
-      <select formControlName="tipoDocumentoAdjunto" class="form-select">
+      <select formControlName="tipoAdjunto" class="form-select">
         <option value="" disabled>-- Selecciona un tipo --</option>
         <option
-          *ngFor="let tipo of tiposDeDocumentoAdjunto"
+          *ngFor="let tipo of tiposAdjunto"
           [value]="tipo"
         >
           {{ tipo }}
@@ -112,8 +112,8 @@
       </select>
       <div
         *ngIf="
-          formulario.get('tipoDocumentoAdjunto')?.invalid &&
-          formulario.get('tipoDocumentoAdjunto')?.touched
+          formulario.get('tipoAdjunto')?.invalid &&
+          formulario.get('tipoAdjunto')?.touched
         "
         class="text-danger"
       >

--- a/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
+++ b/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
@@ -21,7 +21,7 @@ export class FormularioSolicitudComponent implements OnInit {
   archivoSeleccionado: File | null = null;
 
   // Define los posibles tipos de adjunto (ajusta según tu backend)
-  tiposDeDocumentoAdjunto = ['comprobante', 'manifiesto', 'factura'];
+  tiposAdjunto = ['comprobante', 'manifiesto', 'factura'];
 
   constructor(
     private fb: FormBuilder,
@@ -37,7 +37,7 @@ export class FormularioSolicitudComponent implements OnInit {
       numeroDocumento: ['', Validators.required],
       motivo: ['', Validators.required],
       paisOrigen: ['', Validators.required],
-      tipoDocumentoAdjunto: ['', Validators.required],
+      tipoAdjunto: ['', Validators.required],
       // El input file no se asocia directamente a FormControl; lo validamos por código
     });
   }
@@ -70,7 +70,7 @@ export class FormularioSolicitudComponent implements OnInit {
       motivo: f.motivo,
       paisOrigen: f.paisOrigen
     };
-    const tipoAdj = f.tipoDocumentoAdjunto;
+    const tipoAdj = f.tipoAdjunto;
 
     // Convertir archivo a Base64 para enviarlo como JSON
     const reader = new FileReader();

--- a/src/app/services/solicitudes-aduana/solicitud-aduana.ts
+++ b/src/app/services/solicitudes-aduana/solicitud-aduana.ts
@@ -27,7 +27,7 @@ export class SolicitudAduanaService {
    */
   crearConAdjunto(
     data: Omit<SolicitudAduana, 'id' | 'estado' | 'fechaCreacion'>,
-    tipoDocumento: string,
+    tipoAdjunto: string,
     archivoBase64: string
   ): Observable<SolicitudAduana> {
     const params = new HttpParams({
@@ -37,7 +37,7 @@ export class SolicitudAduanaService {
         numeroDocumento: data.numeroDocumento,
         motivo: data.motivo,
         paisOrigen: data.paisOrigen,
-        tipoDocumentoAdjunto: tipoDocumento,
+        tipoAdjunto,
         archivoBase64
       }
     });


### PR DESCRIPTION
## Summary
- align parameter name with server expectation (`tipoAdjunto`)
- update form component to use new name and list

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68411a1e4a4483268b0555f7c3fa90a2