### PR TITLE
Add parent data section to form

### DIFF
--- a/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
+++ b/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
@@ -11,6 +11,107 @@
     [formGroup]="formulario"
     (ngSubmit)="guardar()"
   >
+    <!-- Datos de los padres o tutores legales -->
+    <fieldset class="mb-4">
+      <legend class="fs-5">Datos de los padres o tutores legales</legend>
+
+      <!-- Nombre completo del padre/madre -->
+      <div class="mb-3">
+        <label class="form-label">Nombre completo (Padre/Madre)</label>
+        <input
+          type="text"
+          formControlName="nombrePadreMadre"
+          class="form-control"
+        />
+        <div
+          *ngIf="
+            formulario.get('nombrePadreMadre')?.invalid &&
+            formulario.get('nombrePadreMadre')?.touched
+          "
+          class="text-danger"
+        >
+          El nombre es obligatorio.
+        </div>
+      </div>
+
+      <!-- Relación con el menor -->
+      <div class="mb-3">
+        <label class="form-label">Relación con el menor</label>
+        <select formControlName="relacionMenor" class="form-select">
+          <option value="" disabled>-- Selecciona --</option>
+          <option value="Padre">Padre</option>
+          <option value="Madre">Madre</option>
+          <option value="Tutor legal">Tutor legal</option>
+        </select>
+        <div
+          *ngIf="
+            formulario.get('relacionMenor')?.invalid &&
+            formulario.get('relacionMenor')?.touched
+          "
+          class="text-danger"
+        >
+          Debes indicar la relación con el menor.
+        </div>
+      </div>
+
+      <!-- Documento del padre o tutor -->
+      <div class="mb-3">
+        <label class="form-label">RUT o Pasaporte</label>
+        <input
+          type="text"
+          formControlName="documentoPadre"
+          class="form-control"
+        />
+        <div
+          *ngIf="
+            formulario.get('documentoPadre')?.invalid &&
+            formulario.get('documentoPadre')?.touched
+          "
+          class="text-danger"
+        >
+          El documento es obligatorio.
+        </div>
+      </div>
+
+      <!-- Teléfono -->
+      <div class="mb-3">
+        <label class="form-label">Teléfono de contacto</label>
+        <input
+          type="text"
+          formControlName="telefonoPadre"
+          class="form-control"
+        />
+        <div
+          *ngIf="
+            formulario.get('telefonoPadre')?.invalid &&
+            formulario.get('telefonoPadre')?.touched
+          "
+          class="text-danger"
+        >
+          El teléfono es obligatorio.
+        </div>
+      </div>
+
+      <!-- Email -->
+      <div class="mb-3">
+        <label class="form-label">Email</label>
+        <input
+          type="email"
+          formControlName="emailPadre"
+          class="form-control"
+        />
+        <div
+          *ngIf="
+            formulario.get('emailPadre')?.invalid &&
+            formulario.get('emailPadre')?.touched
+          "
+          class="text-danger"
+        >
+          Ingresa un email válido.
+        </div>
+      </div>
+    </fieldset>
+
     <!-- Nombre del Solicitante -->
     <div class="mb-3">
       <label class="form-label">Nombre Solicitante</label>

--- a/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
+++ b/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
@@ -32,6 +32,11 @@ export class FormularioSolicitudComponent implements OnInit {
   ngOnInit(): void {
     // 1) Construimos el FormGroup con validaciones
     this.formulario = this.fb.group({
+      nombrePadreMadre: ['', Validators.required],
+      relacionMenor: ['', Validators.required],
+      documentoPadre: ['', Validators.required],
+      telefonoPadre: ['', Validators.required],
+      emailPadre: ['', [Validators.required, Validators.email]],
       nombreSolicitante: ['', Validators.required],
       tipoDocumento: ['', Validators.required],
       numeroDocumento: ['', Validators.required],


### PR DESCRIPTION
## Summary
- add a new *Datos de los padres o tutores legales* section at the start of the form
- define form controls for parent's name, relation, document, phone and email

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d214b9d083269419e6e2db1b9f29