### PR TITLE
Transformar campos de documento en botones

### DIFF
--- a/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
+++ b/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
@@ -90,22 +90,38 @@
         </div>
       </div>
 
-      <!-- RUT o Número de pasaporte -->
+      <!-- Tipo Documento del menor -->
       <div class="mb-3">
-        <label class="form-label">RUT o Número de pasaporte</label>
-        <input
-          type="text"
-          formControlName="documentoMenor"
-          class="form-control"
-        />
+        <label class="form-label d-block">Documento del menor</label>
+        <div class="btn-group" role="group" aria-label="Tipo Documento Menor">
+          <input
+            type="radio"
+            class="btn-check"
+            formControlName="documentoMenor"
+            value="RUT"
+            id="menor-rut"
+          />
+          <label class="btn btn-outline-primary" for="menor-rut">RUT</label>
+
+          <input
+            type="radio"
+            class="btn-check"
+            formControlName="documentoMenor"
+            value="Pasaporte"
+            id="menor-pasaporte"
+          />
+          <label class="btn btn-outline-primary" for="menor-pasaporte"
+            >Pasaporte</label
+          >
+        </div>
         <div
           *ngIf="
             formulario.get('documentoMenor')?.invalid &&
             formulario.get('documentoMenor')?.touched
           "
-          class="text-danger"
+          class="text-danger mt-1"
         >
-          El documento es obligatorio.
+          Debes seleccionar el documento.
         </div>
       </div>
 
@@ -177,22 +193,38 @@
         </div>
       </div>
 
-      <!-- Documento del padre o tutor -->
+      <!-- Tipo Documento del padre o tutor -->
       <div class="mb-3">
-        <label class="form-label">RUT o Pasaporte</label>
-        <input
-          type="text"
-          formControlName="documentoPadre"
-          class="form-control"
-        />
+        <label class="form-label d-block">Documento del padre o tutor</label>
+        <div class="btn-group" role="group" aria-label="Tipo Documento Padre">
+          <input
+            type="radio"
+            class="btn-check"
+            formControlName="documentoPadre"
+            value="RUT"
+            id="padre-rut"
+          />
+          <label class="btn btn-outline-primary" for="padre-rut">RUT</label>
+
+          <input
+            type="radio"
+            class="btn-check"
+            formControlName="documentoPadre"
+            value="Pasaporte"
+            id="padre-pasaporte"
+          />
+          <label class="btn btn-outline-primary" for="padre-pasaporte"
+            >Pasaporte</label
+          >
+        </div>
         <div
           *ngIf="
             formulario.get('documentoPadre')?.invalid &&
             formulario.get('documentoPadre')?.touched
           "
-          class="text-danger"
+          class="text-danger mt-1"
         >
-          El documento es obligatorio.
+          Debes seleccionar el documento.
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- cambiar campo "RUT o Número de pasaporte" por botones RUT/Pasaporte
- cambiar campo "RUT o Pasaporte" del padre/tutor por botones RUT/Pasaporte

## Testing
- `npx ng test --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d8c40e888326b64e8602548f9ecf