### PR TITLE
Add dynamic doc fields for parent and child

### DIFF
--- a/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
+++ b/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
@@ -114,16 +114,51 @@
             >Pasaporte</label
           >
         </div>
-        <div
-          *ngIf="
-            formulario.get('documentoMenor')?.invalid &&
-            formulario.get('documentoMenor')?.touched
-          "
-          class="text-danger mt-1"
-        >
-          Debes seleccionar el documento.
-        </div>
+      <div
+        *ngIf="
+          formulario.get('documentoMenor')?.invalid &&
+          formulario.get('documentoMenor')?.touched
+        "
+        class="text-danger mt-1"
+      >
+        Debes seleccionar el documento.
       </div>
+    </div>
+
+    <div class="mb-3" *ngIf="formulario.get('documentoMenor')?.value === 'RUT'">
+      <label class="form-label">RUT del menor</label>
+      <input
+        type="text"
+        formControlName="numeroDocumentoMenor"
+        class="form-control"
+      />
+      <div
+        *ngIf="
+          formulario.get('numeroDocumentoMenor')?.invalid &&
+          formulario.get('numeroDocumentoMenor')?.touched
+        "
+        class="text-danger"
+      >
+        Ingresa un RUT válido.
+      </div>
+    </div>
+    <div class="mb-3" *ngIf="formulario.get('documentoMenor')?.value === 'Pasaporte'">
+      <label class="form-label">Pasaporte del menor</label>
+      <input
+        type="text"
+        formControlName="numeroDocumentoMenor"
+        class="form-control"
+      />
+      <div
+        *ngIf="
+          formulario.get('numeroDocumentoMenor')?.invalid &&
+          formulario.get('numeroDocumentoMenor')?.touched
+        "
+        class="text-danger"
+      >
+        El número de pasaporte es obligatorio.
+      </div>
+    </div>
 
       <!-- Nacionalidad -->
       <div class="mb-3">
@@ -217,16 +252,51 @@
             >Pasaporte</label
           >
         </div>
-        <div
-          *ngIf="
-            formulario.get('documentoPadre')?.invalid &&
-            formulario.get('documentoPadre')?.touched
-          "
-          class="text-danger mt-1"
-        >
-          Debes seleccionar el documento.
-        </div>
+      <div
+        *ngIf="
+          formulario.get('documentoPadre')?.invalid &&
+          formulario.get('documentoPadre')?.touched
+        "
+        class="text-danger mt-1"
+      >
+        Debes seleccionar el documento.
       </div>
+    </div>
+
+    <div class="mb-3" *ngIf="formulario.get('documentoPadre')?.value === 'RUT'">
+      <label class="form-label">RUT del padre o tutor</label>
+      <input
+        type="text"
+        formControlName="numeroDocumentoPadre"
+        class="form-control"
+      />
+      <div
+        *ngIf="
+          formulario.get('numeroDocumentoPadre')?.invalid &&
+          formulario.get('numeroDocumentoPadre')?.touched
+        "
+        class="text-danger"
+      >
+        Ingresa un RUT válido.
+      </div>
+    </div>
+    <div class="mb-3" *ngIf="formulario.get('documentoPadre')?.value === 'Pasaporte'">
+      <label class="form-label">Pasaporte del padre o tutor</label>
+      <input
+        type="text"
+        formControlName="numeroDocumentoPadre"
+        class="form-control"
+      />
+      <div
+        *ngIf="
+          formulario.get('numeroDocumentoPadre')?.invalid &&
+          formulario.get('numeroDocumentoPadre')?.touched
+        "
+        class="text-danger"
+      >
+        El número de pasaporte es obligatorio.
+      </div>
+    </div>
 
       <!-- Teléfono -->
       <div class="mb-3">

--- a/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
+++ b/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
@@ -65,10 +65,12 @@ export class FormularioSolicitudComponent implements OnInit {
       nombreMenor: ['', Validators.required],
       fechaNacimientoMenor: ['', Validators.required],
       documentoMenor: ['', Validators.required],
+      numeroDocumentoMenor: ['', Validators.required],
       nacionalidadMenor: ['', Validators.required],
       nombreSolicitante: ['', Validators.required],
       tipoDocumento: ['', Validators.required],
       numeroDocumento: ['', Validators.required],
+      numeroDocumentoPadre: ['', Validators.required],
       motivo: ['', Validators.required],
       paisOrigen: ['', Validators.required],
       tipoAdjunto: ['', Validators.required],
@@ -77,6 +79,26 @@ export class FormularioSolicitudComponent implements OnInit {
 
     this.formulario.get('tipoDocumento')?.valueChanges.subscribe((tipo) => {
       const control = this.formulario.get('numeroDocumento');
+      if (tipo === 'RUT') {
+        control?.setValidators([Validators.required, rutValidator]);
+      } else {
+        control?.setValidators([Validators.required]);
+      }
+      control?.updateValueAndValidity();
+    });
+
+    this.formulario.get('documentoPadre')?.valueChanges.subscribe((tipo) => {
+      const control = this.formulario.get('numeroDocumentoPadre');
+      if (tipo === 'RUT') {
+        control?.setValidators([Validators.required, rutValidator]);
+      } else {
+        control?.setValidators([Validators.required]);
+      }
+      control?.updateValueAndValidity();
+    });
+
+    this.formulario.get('documentoMenor')?.valueChanges.subscribe((tipo) => {
+      const control = this.formulario.get('numeroDocumentoMenor');
       if (tipo === 'RUT') {
         control?.setValidators([Validators.required, rutValidator]);
       } else {


### PR DESCRIPTION
## Summary
- add form controls for parent and child document numbers
- show number inputs depending on selected document type
- validate RUT values for these new fields

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841dbc389b083268a27def05d29d892