### PR TITLE
Remove duplicate document type field

### DIFF
--- a/src/app/models/solicitud-aduana.ts
+++ b/src/app/models/solicitud-aduana.ts
@@ -3,8 +3,6 @@ import { DocumentoAdjunto } from './documento-adjunto';
 export interface SolicitudAduana {
   id: number;
   nombreSolicitante: string;
-  tipoDocumento: string;
-  numeroDocumento: string;
   motivo: string;
   paisOrigen: string;
   estado?: string;

--- a/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
+++ b/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
@@ -356,74 +356,7 @@
       </div>
     </div>
 
-    <!-- Tipo de Documento -->
-    <div class="mb-3">
-      <label class="form-label d-block">Tipo Documento</label>
-      <div class="btn-group" role="group" aria-label="Tipo Documento">
-        <input
-          type="radio"
-          class="btn-check"
-          formControlName="tipoDocumento"
-          value="RUT"
-          id="tipo-rut"
-        />
-        <label class="btn btn-outline-primary" for="tipo-rut">RUT</label>
-
-        <input
-          type="radio"
-          class="btn-check"
-          formControlName="tipoDocumento"
-          value="Pasaporte"
-          id="tipo-pasaporte"
-        />
-        <label class="btn btn-outline-primary" for="tipo-pasaporte">Pasaporte</label>
-      </div>
-      <div
-        *ngIf="
-          formulario.get('tipoDocumento')?.invalid &&
-          formulario.get('tipoDocumento')?.touched
-        "
-        class="text-danger mt-1"
-      >
-        El tipo de documento es obligatorio.
-      </div>
-    </div>
-
-    <!-- Número de Documento -->
-    <div class="mb-3" *ngIf="formulario.get('tipoDocumento')?.value === 'RUT'">
-      <label class="form-label">RUT</label>
-      <input
-        type="text"
-        formControlName="numeroDocumento"
-        class="form-control"
-      />
-      <div
-        *ngIf="
-          formulario.get('numeroDocumento')?.invalid &&
-          formulario.get('numeroDocumento')?.touched
-        "
-        class="text-danger"
-      >
-        Ingresa un RUT válido.
-      </div>
-    </div>
-    <div class="mb-3" *ngIf="formulario.get('tipoDocumento')?.value === 'Pasaporte'">
-      <label class="form-label">Número Pasaporte</label>
-      <input
-        type="text"
-        formControlName="numeroDocumento"
-        class="form-control"
-      />
-      <div
-        *ngIf="
-          formulario.get('numeroDocumento')?.invalid &&
-          formulario.get('numeroDocumento')?.touched
-        "
-        class="text-danger"
-      >
-        El número de pasaporte es obligatorio.
-      </div>
-    </div>
+    <!-- Tipo de Documento (eliminado) -->
 
     <!-- Motivo -->
     <div class="mb-3">

--- a/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
+++ b/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
@@ -68,23 +68,11 @@ export class FormularioSolicitudComponent implements OnInit {
       numeroDocumentoMenor: ['', Validators.required],
       nacionalidadMenor: ['', Validators.required],
       nombreSolicitante: ['', Validators.required],
-      tipoDocumento: ['', Validators.required],
-      numeroDocumento: ['', Validators.required],
       numeroDocumentoPadre: ['', Validators.required],
       motivo: ['', Validators.required],
       paisOrigen: ['', Validators.required],
       tipoAdjunto: ['', Validators.required],
       // El input file no se asocia directamente a FormControl; lo validamos por código
-    });
-
-    this.formulario.get('tipoDocumento')?.valueChanges.subscribe((tipo) => {
-      const control = this.formulario.get('numeroDocumento');
-      if (tipo === 'RUT') {
-        control?.setValidators([Validators.required, rutValidator]);
-      } else {
-        control?.setValidators([Validators.required]);
-      }
-      control?.updateValueAndValidity();
     });
 
     this.formulario.get('documentoPadre')?.valueChanges.subscribe((tipo) => {
@@ -129,12 +117,13 @@ export class FormularioSolicitudComponent implements OnInit {
 
     // Construir payload con los campos básicos
     const f = this.formulario.value;
-    const payload: Omit<SolicitudAduana, 'id' | 'estado' | 'fechaCreacion'> = {
+    const payload: Omit<
+      SolicitudAduana,
+      'id' | 'estado' | 'fechaCreacion' | 'tipoDocumento' | 'numeroDocumento'
+    > = {
       nombreSolicitante: f.nombreSolicitante,
-      tipoDocumento: f.tipoDocumento,
-      numeroDocumento: f.numeroDocumento,
       motivo: f.motivo,
-      paisOrigen: f.paisOrigen
+      paisOrigen: f.paisOrigen,
     };
     const tipoAdj = f.tipoAdjunto;
 

--- a/src/app/services/solicitudes-aduana/solicitud-aduana.ts
+++ b/src/app/services/solicitudes-aduana/solicitud-aduana.ts
@@ -24,14 +24,15 @@ export class SolicitudAduanaService {
    * Envía la solicitud utilizando `multipart/form-data`.
    */
   crearConAdjunto(
-    data: Omit<SolicitudAduana, 'id' | 'estado' | 'fechaCreacion'>,
+    data: Omit<
+      SolicitudAduana,
+      'id' | 'estado' | 'fechaCreacion' | 'tipoDocumento' | 'numeroDocumento'
+    >,
     tipoAdjunto: string,
     archivo: File
   ): Observable<SolicitudAduana> {
     const formData = new FormData();
     formData.append('nombreSolicitante', data.nombreSolicitante);
-    formData.append('tipoDocumento', data.tipoDocumento);
-    formData.append('numeroDocumento', data.numeroDocumento);
     formData.append('motivo', data.motivo);
     formData.append('paisOrigen', data.paisOrigen);
     formData.append('tipoAdjunto', tipoAdjunto);


### PR DESCRIPTION
## Summary
- remove Tipo Documento and Numero Documento fields from the Solicitud form
- adjust Angular form and payload
- update service and model

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841dcde18108326b7a6b1794b52f7b6