### PR TITLE
Add conditional origin country field

### DIFF
--- a/src/app/models/solicitud-aduana.ts
+++ b/src/app/models/solicitud-aduana.ts
@@ -2,10 +2,12 @@ import { DocumentoAdjunto } from './documento-adjunto';
 
 export interface SolicitudAduana {
   id: number;
-  nombreSolicitante: string;
-  motivo: string;
+  /** Pais de origen del menor */
   paisOrigen: string;
+  /** Datos opcionales mantenidos por retrocompatibilidad */
+  nombreSolicitante?: string;
+  motivo?: string;
   estado?: string;
-  fechaCreacion?: string; 
+  fechaCreacion?: string;
   documentos?: DocumentoAdjunto[];
 }

--- a/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
+++ b/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
@@ -183,6 +183,23 @@
           Debes seleccionar la nacionalidad.
         </div>
       </div>
+
+      <!-- País de Origen (solo entrada) -->
+      <div class="mb-3" *ngIf="formulario.get('tipoSolicitudMenor')?.value === 'Entrada'">
+        <label class="form-label">País de Origen</label>
+        <select formControlName="paisOrigen" class="form-select">
+          <option value="" disabled>-- Selecciona --</option>
+          <option value="Argentina">Argentina</option>
+          <option value="Perú">Perú</option>
+          <option value="Bolivia">Bolivia</option>
+        </select>
+        <div
+          *ngIf="formulario.get('paisOrigen')?.invalid && formulario.get('paisOrigen')?.touched"
+          class="text-danger"
+        >
+          El país de origen es obligatorio.
+        </div>
+      </div>
     </fieldset>
 
     <!-- Datos de los padres o tutores legales -->
@@ -337,95 +354,6 @@
       </div>
     </fieldset>
 
-    <!-- Nombre del Solicitante -->
-    <div class="mb-3">
-      <label class="form-label">Nombre Solicitante</label>
-      <input
-        type="text"
-        formControlName="nombreSolicitante"
-        class="form-control"
-      />
-      <div
-        *ngIf="
-          formulario.get('nombreSolicitante')?.invalid &&
-          formulario.get('nombreSolicitante')?.touched
-        "
-        class="text-danger"
-      >
-        El nombre del solicitante es obligatorio.
-      </div>
-    </div>
-
-    <!-- Tipo de Documento (eliminado) -->
-
-    <!-- Motivo -->
-    <div class="mb-3">
-      <label class="form-label">Motivo</label>
-      <input type="text" formControlName="motivo" class="form-control" />
-      <div
-        *ngIf="
-          formulario.get('motivo')?.invalid &&
-          formulario.get('motivo')?.touched
-        "
-        class="text-danger"
-      >
-        El motivo es obligatorio.
-      </div>
-    </div>
-
-    <!-- País de Origen -->
-    <div class="mb-3">
-      <label class="form-label">País Origen</label>
-      <input type="text" formControlName="paisOrigen" class="form-control" />
-      <div
-        *ngIf="
-          formulario.get('paisOrigen')?.invalid &&
-          formulario.get('paisOrigen')?.touched
-        "
-        class="text-danger"
-      >
-        El país de origen es obligatorio.
-      </div>
-    </div>
-
-    <!-- Tipo de Documento Adjunto -->
-    <div class="mb-3">
-      <label class="form-label">Tipo Documento Adjunto</label>
-      <select formControlName="tipoAdjunto" class="form-select">
-        <option value="" disabled>-- Selecciona un tipo --</option>
-        <option
-          *ngFor="let tipo of tiposAdjunto"
-          [value]="tipo"
-        >
-          {{ tipo }}
-        </option>
-      </select>
-      <div
-        *ngIf="
-          formulario.get('tipoAdjunto')?.invalid &&
-          formulario.get('tipoAdjunto')?.touched
-        "
-        class="text-danger"
-      >
-        Debes elegir un tipo de documento adjunto.
-      </div>
-    </div>
-
-    <!-- Archivo -->
-    <div class="mb-3">
-      <label class="form-label">Archivo (PDF, JPG, etc.)</label>
-      <input
-        type="file"
-        (change)="onFileChange($event)"
-        class="form-control"
-      />
-      <div
-        *ngIf="!archivoSeleccionado"
-        class="text-danger"
-      >
-        Debes seleccionar un archivo.
-      </div>
-    </div>
 
     <!-- Botones -->
     <button

--- a/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
+++ b/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
@@ -39,10 +39,6 @@ export function rutValidator(control: AbstractControl): ValidationErrors | null 
 export class FormularioSolicitudComponent implements OnInit {
   formulario!: FormGroup;
   errorMsg = '';
-  archivoSeleccionado: File | null = null;
-
-  // Define los posibles tipos de adjunto (ajusta según tu backend)
-  tiposAdjunto = ['comprobante', 'manifiesto', 'factura'];
 
   constructor(
     private fb: FormBuilder,
@@ -67,11 +63,8 @@ export class FormularioSolicitudComponent implements OnInit {
       documentoMenor: ['', Validators.required],
       numeroDocumentoMenor: ['', Validators.required],
       nacionalidadMenor: ['', Validators.required],
-      nombreSolicitante: ['', Validators.required],
       numeroDocumentoPadre: ['', Validators.required],
-      motivo: ['', Validators.required],
       paisOrigen: ['', Validators.required],
-      tipoAdjunto: ['', Validators.required],
       // El input file no se asocia directamente a FormControl; lo validamos por código
     });
 
@@ -96,39 +89,21 @@ export class FormularioSolicitudComponent implements OnInit {
     });
   }
 
-  // 2) Capturamos el archivo que el usuario selecciona
-  onFileChange(event: any): void {
-    if (event.target.files && event.target.files.length > 0) {
-      this.archivoSeleccionado = event.target.files[0];
-    }
-  }
-
-  // 3) Manejo del submit
+  // Manejo del submit
   guardar(): void {
     // Validar campos
     if (this.formulario.invalid) {
       this.formulario.markAllAsTouched();
       return;
     }
-    if (!this.archivoSeleccionado) {
-      this.errorMsg = 'Debes seleccionar un archivo.';
-      return;
-    }
-
     // Construir payload con los campos básicos
     const f = this.formulario.value;
-    const payload: Omit<
-      SolicitudAduana,
-      'id' | 'estado' | 'fechaCreacion' | 'tipoDocumento' | 'numeroDocumento'
-    > = {
-      nombreSolicitante: f.nombreSolicitante,
-      motivo: f.motivo,
+    const payload: Pick<SolicitudAduana, 'paisOrigen'> = {
       paisOrigen: f.paisOrigen,
     };
-    const tipoAdj = f.tipoAdjunto;
 
     this.service
-      .crearConAdjunto(payload, tipoAdj, this.archivoSeleccionado)
+      .crearConAdjunto(payload)
       .subscribe({
         next: () => {
           // Al éxito, navegamos al listado

--- a/src/app/services/solicitudes-aduana/solicitud-aduana.ts
+++ b/src/app/services/solicitudes-aduana/solicitud-aduana.ts
@@ -24,19 +24,18 @@ export class SolicitudAduanaService {
    * Envía la solicitud utilizando `multipart/form-data`.
    */
   crearConAdjunto(
-    data: Omit<
-      SolicitudAduana,
-      'id' | 'estado' | 'fechaCreacion' | 'tipoDocumento' | 'numeroDocumento'
-    >,
-    tipoAdjunto: string,
-    archivo: File
+    data: Pick<SolicitudAduana, 'paisOrigen'>,
+    tipoAdjunto?: string,
+    archivo?: File
   ): Observable<SolicitudAduana> {
     const formData = new FormData();
-    formData.append('nombreSolicitante', data.nombreSolicitante);
-    formData.append('motivo', data.motivo);
     formData.append('paisOrigen', data.paisOrigen);
-    formData.append('tipoAdjunto', tipoAdjunto);
-    formData.append('archivo', archivo, archivo.name);
+    if (tipoAdjunto) {
+      formData.append('tipoAdjunto', tipoAdjunto);
+    }
+    if (archivo) {
+      formData.append('archivo', archivo, archivo.name);
+    }
 
     return this.http.post<SolicitudAduana>(this.baseUrl, formData);
   }


### PR DESCRIPTION
## Summary
- remove unused applicant and attachment fields from aduana form
- show new *País de Origen* dropdown when "Entrada" type is selected
- simplify save logic to only send `paisOrigen`
- update service and model to match new payload

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841fdf433d48326b5e260ee3850d25b