### PR TITLE
Add País de Destino field

### DIFF
--- a/src/app/models/solicitud-aduana.ts
+++ b/src/app/models/solicitud-aduana.ts
@@ -4,6 +4,8 @@ export interface SolicitudAduana {
   id: number;
   /** Pais de origen del menor */
   paisOrigen: string;
+  /** Pais de destino del menor */
+  paisDestino?: string;
   /** Datos opcionales mantenidos por retrocompatibilidad */
   nombreSolicitante?: string;
   motivo?: string;

--- a/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
+++ b/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
@@ -200,6 +200,23 @@
           El país de origen es obligatorio.
         </div>
       </div>
+
+      <!-- País de Destino (solo salida) -->
+      <div class="mb-3" *ngIf="formulario.get('tipoSolicitudMenor')?.value === 'Salida'">
+        <label class="form-label">País de Destino</label>
+        <select formControlName="paisDestino" class="form-select">
+          <option value="" disabled>-- Selecciona --</option>
+          <option value="Argentina">Argentina</option>
+          <option value="Perú">Perú</option>
+          <option value="Bolivia">Bolivia</option>
+        </select>
+        <div
+          *ngIf="formulario.get('paisDestino')?.invalid && formulario.get('paisDestino')?.touched"
+          class="text-danger"
+        >
+          El país de destino es obligatorio.
+        </div>
+      </div>
     </fieldset>
 
     <!-- Datos de los padres o tutores legales -->

--- a/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
+++ b/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
@@ -65,6 +65,7 @@ export class FormularioSolicitudComponent implements OnInit {
       nacionalidadMenor: ['', Validators.required],
       numeroDocumentoPadre: ['', Validators.required],
       paisOrigen: ['', Validators.required],
+      paisDestino: ['', Validators.required],
       // El input file no se asocia directamente a FormControl; lo validamos por código
     });
 
@@ -87,6 +88,25 @@ export class FormularioSolicitudComponent implements OnInit {
       }
       control?.updateValueAndValidity();
     });
+
+    this.formulario.get('tipoSolicitudMenor')?.valueChanges.subscribe((tipo) => {
+      const paisOrigenCtrl = this.formulario.get('paisOrigen');
+      const paisDestinoCtrl = this.formulario.get('paisDestino');
+      if (tipo === 'Entrada') {
+        paisOrigenCtrl?.setValidators([Validators.required]);
+        paisDestinoCtrl?.clearValidators();
+        paisDestinoCtrl?.setValue('');
+      } else if (tipo === 'Salida') {
+        paisDestinoCtrl?.setValidators([Validators.required]);
+        paisOrigenCtrl?.clearValidators();
+        paisOrigenCtrl?.setValue('');
+      } else {
+        paisOrigenCtrl?.clearValidators();
+        paisDestinoCtrl?.clearValidators();
+      }
+      paisOrigenCtrl?.updateValueAndValidity();
+      paisDestinoCtrl?.updateValueAndValidity();
+    });
   }
 
   // Manejo del submit
@@ -98,8 +118,9 @@ export class FormularioSolicitudComponent implements OnInit {
     }
     // Construir payload con los campos básicos
     const f = this.formulario.value;
-    const payload: Pick<SolicitudAduana, 'paisOrigen'> = {
+    const payload: Pick<SolicitudAduana, 'paisOrigen' | 'paisDestino'> = {
       paisOrigen: f.paisOrigen,
+      paisDestino: f.paisDestino,
     };
 
     this.service

--- a/src/app/services/solicitudes-aduana/solicitud-aduana.ts
+++ b/src/app/services/solicitudes-aduana/solicitud-aduana.ts
@@ -24,12 +24,15 @@ export class SolicitudAduanaService {
    * Envía la solicitud utilizando `multipart/form-data`.
    */
   crearConAdjunto(
-    data: Pick<SolicitudAduana, 'paisOrigen'>,
+    data: Pick<SolicitudAduana, 'paisOrigen' | 'paisDestino'>,
     tipoAdjunto?: string,
     archivo?: File
   ): Observable<SolicitudAduana> {
     const formData = new FormData();
     formData.append('paisOrigen', data.paisOrigen);
+    if (data.paisDestino) {
+      formData.append('paisDestino', data.paisDestino);
+    }
     if (tipoAdjunto) {
       formData.append('tipoAdjunto', tipoAdjunto);
     }


### PR DESCRIPTION
## Summary
- extend `SolicitudAduana` model to include `paisDestino`
- allow sending destination country in `SolicitudAduanaService`
- add `paisDestino` form control with validators
- show `País de Destino` field when `tipoSolicitudMenor` is "Salida"
- switch validators for origin/destination based on request type

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ff6a39008326b58c6b4cf76c1a8e