### PR TITLE
fix solicitud service params

### DIFF
--- a/src/app/services/solicitudes-aduana/solicitud-aduana.ts
+++ b/src/app/services/solicitudes-aduana/solicitud-aduana.ts
@@ -27,14 +27,18 @@ export class SolicitudAduanaService {
    */
   crearConAdjunto(
     data: Omit<SolicitudAduana, 'id' | 'estado' | 'fechaCreacion'>,
-    tipoDocumento: string,
-    archivoBase64: string
+    tipoDocumento = '',
+    archivoBase64 = ''
   ): Observable<SolicitudAduana> {
-    const payload = {
+    const payload: any = {
       ...data,
-      tipoDocumentoAdjunto: tipoDocumento,
-      archivoBase64
     };
+    if (tipoDocumento) {
+      payload.tipoDocumentoAdjunto = tipoDocumento;
+    }
+    if (archivoBase64) {
+      payload.archivoBase64 = archivoBase64;
+    }
     return this.http.post<SolicitudAduana>(this.baseUrl, payload);
   }
 }


### PR DESCRIPTION
## Summary
- allow optional `tipoDocumento` and `archivoBase64` when creating a solicitud

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420a717d5c8326995efae81487a3a9