### PR TITLE
Add attachments section and text field for travel reason

### DIFF
--- a/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
+++ b/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
@@ -292,12 +292,7 @@
       <!-- Motivo del viaje -->
       <div class="mb-3">
         <label class="form-label">Motivo del viaje</label>
-        <select formControlName="motivoViaje" class="form-select">
-          <option value="" disabled>-- Selecciona --</option>
-          <option value="Vacaciones">Vacaciones</option>
-          <option value="Estudios">Estudios</option>
-          <option value="Visita familiar">Visita familiar</option>
-        </select>
+        <input type="text" formControlName="motivoViaje" class="form-control" />
         <div
           *ngIf="formulario.get('motivoViaje')?.invalid && formulario.get('motivoViaje')?.touched"
           class="text-danger"
@@ -482,14 +477,67 @@
       </div>
       </fieldset>
     </div>
-    <div
-      *ngIf="!datosPadreVisible"
-      class="section-collapsed mb-4 d-flex justify-content-between align-items-center"
-      (click)="togglePadre()"
-    >
-      <span>Datos de los padres o tutores legales</span>
-      <span class="toggle-arrow">&#9660;</span>
-    </div>
+  <div
+    *ngIf="!datosPadreVisible"
+    class="section-collapsed mb-4 d-flex justify-content-between align-items-center"
+    (click)="togglePadre()"
+  >
+    <span>Datos de los padres o tutores legales</span>
+    <span class="toggle-arrow">&#9660;</span>
+  </div>
+
+  <!-- Documentos Adjuntos -->
+  <div
+    class="section-wrapper mb-4"
+    [@expandCollapse]="datosDocumentosVisible ? 'expanded' : 'collapsed'"
+  >
+    <fieldset>
+      <legend class="fs-5 d-flex justify-content-between align-items-center">
+        <span>Documentos Adjuntos</span>
+        <button
+          type="button"
+          class="toggle-btn"
+          aria-label="Minimizar"
+          (click)="toggleDocumentos()"
+        >
+          <span [class.rotated]="datosDocumentosVisible">&#9660;</span>
+        </button>
+      </legend>
+
+      <div class="mb-3">
+        <label class="form-label">Cédula de identidad o pasaporte del menor</label>
+        <input type="file" (change)="onArchivoSeleccionado($event, 'idMenor')" class="form-control" />
+      </div>
+
+      <div class="mb-3" *ngIf="formulario.get('nacionalidadMenor')?.value === 'Chilena'">
+        <label class="form-label">Certificado de nacimiento</label>
+        <input type="file" (change)="onArchivoSeleccionado($event, 'certNacimiento')" class="form-control" />
+      </div>
+
+      <div class="mb-3" *ngIf="formulario.get('nacionalidadMenor')?.value === 'Chilena'">
+        <label class="form-label">Permiso notarial firmado por ambos padres</label>
+        <input type="file" (change)="onArchivoSeleccionado($event, 'permisoNotarial')" class="form-control" />
+      </div>
+
+      <div class="mb-3">
+        <label class="form-label">Cédula de los padres o tutor</label>
+        <input type="file" (change)="onArchivoSeleccionado($event, 'idPadres')" class="form-control" />
+      </div>
+
+      <div class="mb-3">
+        <label class="form-label">Pasaje o itinerario de viaje</label>
+        <input type="file" (change)="onArchivoSeleccionado($event, 'pasajeItinerario')" class="form-control" />
+      </div>
+    </fieldset>
+  </div>
+  <div
+    *ngIf="!datosDocumentosVisible"
+    class="section-collapsed mb-4 d-flex justify-content-between align-items-center"
+    (click)="toggleDocumentos()"
+  >
+    <span>Documentos Adjuntos</span>
+    <span class="toggle-arrow">&#9660;</span>
+  </div>
 
 
     <!-- Botones -->

--- a/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
+++ b/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
@@ -68,6 +68,15 @@ export class FormularioSolicitudComponent implements OnInit {
   datosMenorVisible = false;
   datosPadreVisible = false;
   datosViajeVisible = false;
+  datosDocumentosVisible = false;
+
+  adjuntos: Record<string, File | null> = {
+    idMenor: null,
+    certNacimiento: null,
+    permisoNotarial: null,
+    idPadres: null,
+    pasajeItinerario: null,
+  };
 
   constructor(
     private fb: FormBuilder,
@@ -184,6 +193,17 @@ export class FormularioSolicitudComponent implements OnInit {
 
   toggleViaje(): void {
     this.datosViajeVisible = !this.datosViajeVisible;
+  }
+
+  toggleDocumentos(): void {
+    this.datosDocumentosVisible = !this.datosDocumentosVisible;
+  }
+
+  onArchivoSeleccionado(event: Event, tipo: string): void {
+    const input = event.target as HTMLInputElement;
+    if (input.files && input.files.length > 0) {
+      this.adjuntos[tipo] = input.files[0];
+    }
   }
 
   cancelar(): void {


### PR DESCRIPTION
## Summary
- update travel reason to a plain text input
- allow toggling and selecting attached documents

## Testing
- `npm test --silent --unsafe-perm --if-present` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420f90fa0c8326819842bb11849b2e