### PR TITLE
Add home page with solicitud buttons

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -4,6 +4,7 @@ import { Routes } from '@angular/router';
 
 // Importamos solo los componentes que realmente tenemos en este momento:
 import { FormularioSolicitudComponent } from './pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud';
+import { InicioComponent } from './pages/inicio/inicio';
 
 /**
  * Nota: Hemos comentado (o eliminado) las rutas de listado y detalle 
@@ -12,15 +13,15 @@ import { FormularioSolicitudComponent } from './pages/solicitudes-aduana/formula
  * los vuelves a descomentar y agregas aquí.
  */
 export const routes: Routes = [
-  // 1) La ruta raíz redirige directamente al formulario (por ahora)
-  { path: '', redirectTo: 'solicitud-aduana/nuevo', pathMatch: 'full' },
+  // Página de inicio con las opciones disponibles
+  { path: '', component: InicioComponent },
 
-  // 2) Ruta para crear nueva solicitud
+  // Ruta para crear nueva solicitud
   { path: 'solicitud-aduana/nuevo', component: FormularioSolicitudComponent },
 
   // 3) Editar una solicitud (usa el mismo componente de formulario)
   { path: 'solicitud-aduana/editar/:id', component: FormularioSolicitudComponent },
 
-  // 4) Cualquier otra URL → Volver al formulario (o a listado cuando exista)
-  { path: '**', redirectTo: 'solicitud-aduana/nuevo' }
+  // 4) Cualquier otra URL → Volver al inicio
+  { path: '**', redirectTo: '' }
 ];

--- a/src/app/pages/inicio/inicio.html
+++ b/src/app/pages/inicio/inicio.html
@@ -1,0 +1,6 @@
+<div class="page-container">
+  <h2 class="mb-4">Solicitudes Disponibles</h2>
+  <a routerLink="/solicitud-aduana/nuevo" class="btn btn-primary solicitud-btn">
+    <span class="me-2">🧒✈️</span> Solicitud Viaje de Menor
+  </a>
+</div>

--- a/src/app/pages/inicio/inicio.scss
+++ b/src/app/pages/inicio/inicio.scss
@@ -1,0 +1,9 @@
+.page-container {
+  text-align: center;
+  margin-top: 4rem;
+}
+
+.solicitud-btn {
+  font-size: 1.5rem;
+  padding: 2rem 3rem;
+}

--- a/src/app/pages/inicio/inicio.spec.ts
+++ b/src/app/pages/inicio/inicio.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { InicioComponent } from './inicio';
+
+describe('InicioComponent', () => {
+  let component: InicioComponent;
+  let fixture: ComponentFixture<InicioComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [InicioComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(InicioComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/inicio/inicio.ts
+++ b/src/app/pages/inicio/inicio.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-inicio',
+  standalone: true,
+  imports: [RouterModule, CommonModule],
+  templateUrl: './inicio.html',
+  styleUrls: ['./inicio.scss']
+})
+export class InicioComponent {}


### PR DESCRIPTION
## Summary
- add a new `InicioComponent` with large button to create "Solicitud Viaje de Menor"
- hook the new page in routing so the root path shows available solicitudes

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421c15d4cc8326b28a78ed301c9784