### PR TITLE
Add local Aduana logo

### DIFF
--- a/public/logo-aduana.svg
+++ b/public/logo-aduana.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect width="200" height="200" fill="#003366"/>
+  <polygon points="100,30 116,80 170,80 126,110 144,160 100,130 56,160 74,110 30,80 84,80" fill="white"/>
+  <text x="100" y="185" text-anchor="middle" font-size="40" fill="white" font-family="Arial, Helvetica, sans-serif">ADUANAS</text>
+</svg>

--- a/src/app/pages/inicio/inicio.html
+++ b/src/app/pages/inicio/inicio.html
@@ -1,6 +1,6 @@
 <div class="page-container text-center">
   <img
-    src="https://upload.wikimedia.org/wikipedia/commons/6/64/Logo_Aduanas_de_Chile.png"
+    src="logo-aduana.svg"
     alt="Logo Aduanas de Chile"
     class="mb-4"
     width="200"


### PR DESCRIPTION
## Summary
- add custom Aduana logo as local asset
- update homepage to use the local logo

## Testing
- `npm test` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684224b5938483268314678e5f7c17c5