### PR TITLE
Update logo and position on home page

### DIFF
--- a/public/logo-aduana.svg
+++ b/public/logo-aduana.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
-  <rect width="200" height="200" fill="#003366"/>
-  <polygon points="100,30 116,80 170,80 126,110 144,160 100,130 56,160 74,110 30,80 84,80" fill="white"/>
-  <text x="100" y="185" text-anchor="middle" font-size="40" fill="white" font-family="Arial, Helvetica, sans-serif">ADUANAS</text>
+  <circle cx="100" cy="100" r="95" fill="#0055A4" />
+  <path d="M100 35 L115 80 H165 L125 110 L140 160 L100 130 L60 160 L75 110 L35 80 H85 Z" fill="#FFFFFF" />
+  <text x="100" y="185" text-anchor="middle" font-size="32" fill="#FFFFFF" font-family="Arial, Helvetica, sans-serif">ADUANAS</text>
 </svg>

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -2,7 +2,8 @@
 
 <header class="bg-dark text-white p-3">
   <div class="container d-flex justify-content-between align-items-center">
-    <a routerLink="/" class="text-white text-decoration-none">
+    <a routerLink="/" class="text-white d-flex align-items-center text-decoration-none">
+      <img src="logo-aduana.svg" alt="Logo Aduanas de Chile" width="40" height="40" class="me-2" />
       <h1 class="h4 m-0">Sistema Aduanero</h1>
     </a>
   </div>

--- a/src/app/pages/inicio/inicio.html
+++ b/src/app/pages/inicio/inicio.html
@@ -1,10 +1,4 @@
 <div class="page-container text-center">
-  <img
-    src="logo-aduana.svg"
-    alt="Logo Aduanas de Chile"
-    class="mb-4"
-    width="200"
-  />
   <h2 class="mb-4">Solicitudes Disponibles</h2>
   <a routerLink="/solicitud-aduana/nuevo" class="btn btn-primary solicitud-btn">
     <span class="me-2">🧒✈️</span> Solicitud Viaje de Menor


### PR DESCRIPTION
## Summary
- replace the logo with an improved SVG image
- display the logo in the site header
- remove redundant logo from the home page

## Testing
- `npx ng test --watch=false` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684235be5278832696407164efa22d04