### PR TITLE
Fix logo shift on section expansion

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,1 +1,16 @@
 /* You can add global styles to this file, and also import other style files */
+
+/*
+  When expanding form sections the page might toggle the vertical scrollbar,
+  causing a subtle horizontal shift in the header and its logo. Always showing
+  the scrollbar prevents this layout jump.
+*/
+html,
+body {
+  height: 100%;
+}
+
+body {
+  min-height: 100%;
+  overflow-y: scroll;
+}


### PR DESCRIPTION
## Summary
- avoid layout jump when toggling collapsible sections by forcing vertical scrollbar

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684236f872148326a1385b7c30e8380d