### PR TITLE
Fix missing tipoDocumento parameter

### DIFF
--- a/src/app/services/solicitudes-aduana/solicitud-aduana.ts
+++ b/src/app/services/solicitudes-aduana/solicitud-aduana.ts
@@ -40,10 +40,20 @@ export class SolicitudAduanaService {
       payload.archivoBase64 = archivoBase64;
     }
 
-    const params = data.nombreSolicitante
-      ? new HttpParams().set('nombreSolicitante', data.nombreSolicitante)
-      : undefined;
+    let params: HttpParams | undefined;
+    if (data.nombreSolicitante) {
+      params = new HttpParams().set(
+        'nombreSolicitante',
+        data.nombreSolicitante
+      );
+    }
 
-    return this.http.post<SolicitudAduana>(this.baseUrl, payload, { params });
+    if (tipoDocumento) {
+      params = (params ?? new HttpParams()).set('tipoDocumento', tipoDocumento);
+    }
+
+    return this.http.post<SolicitudAduana>(this.baseUrl, payload, {
+      params,
+    });
   }
 }


### PR DESCRIPTION
## Summary
- send `tipoDocumento` as query param when creating a request

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844db2baa208326a986476dbf5e14b3