### PR TITLE
Fix missing numeroDocumento param

### DIFF
--- a/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
+++ b/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
@@ -187,7 +187,12 @@ export class FormularioSolicitudComponent implements OnInit {
     const adjunto = this.adjuntos['idMenor'];
     const enviar = (base64?: string) =>
       this.service
-        .crearConAdjunto(payload, 'idMenor', base64 ?? '')
+        .crearConAdjunto(
+          payload,
+          'idMenor',
+          f.numeroDocumentoMenor,
+          base64 ?? ''
+        )
         .subscribe({
           next: () => {
             // Al éxito, navegamos al listado

--- a/src/app/services/solicitudes-aduana/solicitud-aduana.ts
+++ b/src/app/services/solicitudes-aduana/solicitud-aduana.ts
@@ -28,6 +28,7 @@ export class SolicitudAduanaService {
   crearConAdjunto(
     data: Omit<SolicitudAduana, 'id' | 'estado' | 'fechaCreacion'>,
     tipoDocumento = '',
+    numeroDocumento = '',
     archivoBase64 = ''
   ): Observable<SolicitudAduana> {
     const payload: any = {
@@ -50,6 +51,13 @@ export class SolicitudAduanaService {
 
     if (tipoDocumento) {
       params = (params ?? new HttpParams()).set('tipoDocumento', tipoDocumento);
+    }
+
+    if (numeroDocumento) {
+      params = (params ?? new HttpParams()).set(
+        'numeroDocumento',
+        numeroDocumento
+      );
     }
 
     return this.http.post<SolicitudAduana>(this.baseUrl, payload, {


### PR DESCRIPTION
## Summary
- include `numeroDocumento` parameter when creating an attached solicitud
- pass the minor's document number from the form

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844e63e7c6c8326b5c5b97f9e2faed1