### PR TITLE
Fix form payload to send all travel request fields

### DIFF
--- a/src/app/models/adjunto-viaje-menor.ts
+++ b/src/app/models/adjunto-viaje-menor.ts
@@ -1,0 +1,7 @@
+export interface AdjuntoViajeMenor {
+  id: number;
+  nombreArchivo: string;
+  ruta: string;
+  // Identificador de la solicitud; opcional para facilitar creacion
+  solicitud?: number;
+}

--- a/src/app/models/solicitud-viaje-menor.ts
+++ b/src/app/models/solicitud-viaje-menor.ts
@@ -1,0 +1,25 @@
+import { AdjuntoViajeMenor } from './adjunto-viaje-menor';
+
+export interface SolicitudViajeMenor {
+  id: number;
+  estado: string;
+  fechaCreacion: string;
+  tipoSolicitudMenor: string;
+  nombreMenor: string;
+  fechaNacimientoMenor: string;
+  documentoMenor: string;
+  numeroDocumentoMenor: string;
+  nacionalidadMenor: string;
+  nombrePadreMadre: string;
+  relacionMenor: string;
+  documentoPadre: string;
+  numeroDocumentoPadre: string;
+  telefonoPadre: string;
+  emailPadre: string;
+  fechaViaje: string;
+  numeroTransporte: string;
+  paisOrigen: string;
+  paisDestino: string;
+  motivoViaje: string;
+  documentos: AdjuntoViajeMenor[];
+}

--- a/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
+++ b/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
@@ -12,7 +12,7 @@ import { FormBuilder, FormGroup, Validators, ReactiveFormsModule, AbstractContro
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { SolicitudAduanaService } from '../../../services/solicitudes-aduana/solicitud-aduana';
-import { SolicitudAduana } from '../../../models/solicitud-aduana';
+import { SolicitudViajeMenor } from '../../../models/solicitud-viaje-menor';
 import { RouterModule } from '@angular/router';
 
 export function rutValidator(control: AbstractControl): ValidationErrors | null {
@@ -174,13 +174,26 @@ export class FormularioSolicitudComponent implements OnInit {
     }
     // Construir payload con los campos básicos
     const f = this.formulario.value;
-    const payload: Pick<SolicitudAduana,
-      'nombreSolicitante' | 'paisOrigen' | 'paisDestino' | 'fechaViaje' | 'numeroTransporte' | 'motivoViaje'> = {
-      nombreSolicitante: f.nombrePadreMadre,
-      paisOrigen: f.paisOrigen,
-      paisDestino: f.paisDestino,
+    const payload: Omit<
+      SolicitudViajeMenor,
+      'id' | 'estado' | 'fechaCreacion' | 'documentos'
+    > = {
+      tipoSolicitudMenor: f.tipoSolicitudMenor,
+      nombreMenor: f.nombreMenor,
+      fechaNacimientoMenor: f.fechaNacimientoMenor,
+      documentoMenor: f.documentoMenor,
+      numeroDocumentoMenor: f.numeroDocumentoMenor,
+      nacionalidadMenor: f.nacionalidadMenor,
+      nombrePadreMadre: f.nombrePadreMadre,
+      relacionMenor: f.relacionMenor,
+      documentoPadre: f.documentoPadre,
+      numeroDocumentoPadre: f.numeroDocumentoPadre,
+      telefonoPadre: f.telefonoPadre,
+      emailPadre: f.emailPadre,
       fechaViaje: f.fechaViaje,
       numeroTransporte: f.numeroTransporte,
+      paisOrigen: f.paisOrigen,
+      paisDestino: f.paisDestino,
       motivoViaje: f.motivoViaje,
     };
 

--- a/src/app/services/solicitudes-aduana/solicitud-aduana.ts
+++ b/src/app/services/solicitudes-aduana/solicitud-aduana.ts
@@ -3,7 +3,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { SolicitudAduana } from '../../models/solicitud-aduana';
+import { SolicitudViajeMenor } from '../../models/solicitud-viaje-menor';
 
 @Injectable({ providedIn: 'root' })
 export class SolicitudAduanaService {
@@ -26,11 +26,14 @@ export class SolicitudAduanaService {
    * backend sólo acepta application/json.
    */
   crearConAdjunto(
-    data: Omit<SolicitudAduana, 'id' | 'estado' | 'fechaCreacion'>,
+    data: Omit<
+      SolicitudViajeMenor,
+      'id' | 'estado' | 'fechaCreacion' | 'documentos'
+    >,
     tipoDocumento = '',
     numeroDocumento = '',
     archivoBase64 = ''
-  ): Observable<SolicitudAduana> {
+  ): Observable<SolicitudViajeMenor> {
     const payload: any = {
       ...data,
     };
@@ -42,17 +45,9 @@ export class SolicitudAduanaService {
     }
 
     let params: HttpParams | undefined;
-    if (data.nombreSolicitante) {
-      params = new HttpParams().set(
-        'nombreSolicitante',
-        data.nombreSolicitante
-      );
-    }
-
     if (tipoDocumento) {
-      params = (params ?? new HttpParams()).set('tipoDocumento', tipoDocumento);
+      params = new HttpParams().set('tipoDocumento', tipoDocumento);
     }
-
     if (numeroDocumento) {
       params = (params ?? new HttpParams()).set(
         'numeroDocumento',
@@ -60,7 +55,7 @@ export class SolicitudAduanaService {
       );
     }
 
-    return this.http.post<SolicitudAduana>(this.baseUrl, payload, {
+    return this.http.post<SolicitudViajeMenor>(this.baseUrl, payload, {
       params,
     });
   }


### PR DESCRIPTION
## Summary
- add models for `SolicitudViajeMenor` and `AdjuntoViajeMenor`
- update service to send the full `SolicitudViajeMenor` payload
- adapt the form to build and send this new payload

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844e792f5788326a8b35eab5f398d1a