### PR TITLE
Fix missing request parameter

### DIFF
--- a/src/app/services/solicitudes-aduana/solicitud-aduana.ts
+++ b/src/app/services/solicitudes-aduana/solicitud-aduana.ts
@@ -45,8 +45,14 @@ export class SolicitudAduanaService {
     }
 
     let params: HttpParams | undefined;
+    if (data.nombrePadreMadre) {
+      params = new HttpParams().set(
+        'nombreSolicitante',
+        data.nombrePadreMadre
+      );
+    }
     if (tipoDocumento) {
-      params = new HttpParams().set('tipoDocumento', tipoDocumento);
+      params = (params ?? new HttpParams()).set('tipoDocumento', tipoDocumento);
     }
     if (numeroDocumento) {
       params = (params ?? new HttpParams()).set(


### PR DESCRIPTION
## Summary
- send `nombreSolicitante` query param again

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844e9f2e5048326b6e8795bd582bfb5