### PR TITLE
Fix missing tipoAdjunto parameter

### DIFF
--- a/src/app/services/solicitudes-aduana/solicitud-aduana.ts
+++ b/src/app/services/solicitudes-aduana/solicitud-aduana.ts
@@ -30,15 +30,15 @@ export class SolicitudAduanaService {
       SolicitudViajeMenor,
       'id' | 'estado' | 'fechaCreacion' | 'documentos'
     >,
-    tipoDocumento = '',
+    tipoAdjunto = '',
     numeroDocumento = '',
     archivoBase64 = ''
   ): Observable<SolicitudViajeMenor> {
     const payload: any = {
       ...data,
     };
-    if (tipoDocumento) {
-      payload.tipoDocumentoAdjunto = tipoDocumento;
+    if (tipoAdjunto) {
+      payload.tipoAdjunto = tipoAdjunto;
     }
     if (archivoBase64) {
       payload.archivoBase64 = archivoBase64;
@@ -51,8 +51,8 @@ export class SolicitudAduanaService {
         data.nombrePadreMadre
       );
     }
-    if (tipoDocumento) {
-      params = (params ?? new HttpParams()).set('tipoDocumento', tipoDocumento);
+    if (tipoAdjunto) {
+      params = (params ?? new HttpParams()).set('tipoAdjunto', tipoAdjunto);
     }
     if (numeroDocumento) {
       params = (params ?? new HttpParams()).set(


### PR DESCRIPTION
## Summary
- send `tipoAdjunto` instead of `tipoDocumento`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844eb1271b0832695ea9f8cf27bf827