### PR TITLE
Actualizar formulario de solicitud

### DIFF
--- a/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
+++ b/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
@@ -6,6 +6,9 @@
   <div *ngIf="errorMsg" class="alert alert-danger">
     {{ errorMsg }}
   </div>
+  <div *ngIf="successMsg" class="alert alert-success">
+    {{ successMsg }}
+  </div>
 
   <form
     [formGroup]="formulario"
@@ -609,7 +612,7 @@
     class="btn btn-primary me-2"
     [disabled]="formulario.invalid"
   >
-    Guardar Solicitud
+    Enviar Solicitud
   </button>
   <button
     type="button"
@@ -618,5 +621,8 @@
   >
     Cancelar
   </button>
+  <div *ngIf="submitAttempted && formulario.invalid" class="text-danger mt-2">
+    El formulario tiene errores en alguno de sus campos.
+  </div>
 </form>
 </div>

--- a/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
+++ b/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
@@ -114,6 +114,8 @@ export function fechaViajeValidator(control: AbstractControl): ValidationErrors 
 export class FormularioSolicitudComponent implements OnInit {
   formulario!: FormGroup;
   errorMsg = '';
+  successMsg = '';
+  submitAttempted = false;
   datosMenorVisible = false;
   datosPadreVisible = false;
   datosViajeVisible = false;
@@ -204,6 +206,7 @@ export class FormularioSolicitudComponent implements OnInit {
 
   // Manejo del submit
   guardar(): void {
+    this.submitAttempted = true;
     // Validar campos
     if (this.formulario.invalid) {
       this.formulario.markAllAsTouched();
@@ -246,8 +249,9 @@ export class FormularioSolicitudComponent implements OnInit {
       )
       .subscribe({
         next: () => {
-          alert('Solicitud enviada correctamente.');
-          this.router.navigate(['/solicitud-aduana']);
+          this.successMsg = 'Solicitud enviada correctamente.';
+          this.errorMsg = '';
+          setTimeout(() => this.router.navigate(['/solicitud-aduana']), 1500);
         },
         error: (err) => {
           console.error('Error al crear solicitud:', err);
@@ -258,39 +262,54 @@ export class FormularioSolicitudComponent implements OnInit {
   }
 
   toggleMenor(): void {
+    if (this.tieneErroresMenor()) {
+      this.datosMenorVisible = true;
+      return;
+    }
     this.datosMenorVisible = !this.datosMenorVisible;
     if (this.datosMenorVisible) {
-      if (!this.tieneErroresPadre()) this.datosPadreVisible = false;
-      if (!this.tieneErroresViaje()) this.datosViajeVisible = false;
-      if (!this.tieneErroresDocumentos()) this.datosDocumentosVisible = false;
+      this.cerrarSeccionesExcepto('menor');
     }
   }
 
   togglePadre(): void {
+    if (this.tieneErroresPadre()) {
+      this.datosPadreVisible = true;
+      return;
+    }
     this.datosPadreVisible = !this.datosPadreVisible;
     if (this.datosPadreVisible) {
-      if (!this.tieneErroresMenor()) this.datosMenorVisible = false;
-      if (!this.tieneErroresViaje()) this.datosViajeVisible = false;
-      if (!this.tieneErroresDocumentos()) this.datosDocumentosVisible = false;
+      this.cerrarSeccionesExcepto('padre');
     }
   }
 
   toggleViaje(): void {
+    if (this.tieneErroresViaje()) {
+      this.datosViajeVisible = true;
+      return;
+    }
     this.datosViajeVisible = !this.datosViajeVisible;
     if (this.datosViajeVisible) {
-      if (!this.tieneErroresMenor()) this.datosMenorVisible = false;
-      if (!this.tieneErroresPadre()) this.datosPadreVisible = false;
-      if (!this.tieneErroresDocumentos()) this.datosDocumentosVisible = false;
+      this.cerrarSeccionesExcepto('viaje');
     }
   }
 
   toggleDocumentos(): void {
+    if (this.tieneErroresDocumentos()) {
+      this.datosDocumentosVisible = true;
+      return;
+    }
     this.datosDocumentosVisible = !this.datosDocumentosVisible;
     if (this.datosDocumentosVisible) {
-      if (!this.tieneErroresMenor()) this.datosMenorVisible = false;
-      if (!this.tieneErroresPadre()) this.datosPadreVisible = false;
-      if (!this.tieneErroresViaje()) this.datosViajeVisible = false;
+      this.cerrarSeccionesExcepto('documentos');
     }
+  }
+
+  private cerrarSeccionesExcepto(seccion: 'menor' | 'padre' | 'viaje' | 'documentos'): void {
+    if (seccion !== 'menor' && !this.tieneErroresMenor()) this.datosMenorVisible = false;
+    if (seccion !== 'padre' && !this.tieneErroresPadre()) this.datosPadreVisible = false;
+    if (seccion !== 'viaje' && !this.tieneErroresViaje()) this.datosViajeVisible = false;
+    if (seccion !== 'documentos' && !this.tieneErroresDocumentos()) this.datosDocumentosVisible = false;
   }
 
   formatearRut(event: Event, controlName: string): void {


### PR DESCRIPTION
## Summary
- show success alert and rename button to 'Enviar Solicitud'
- block collapsing of sections with errors and automatically close others
- display error notice when form submission fails

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684540f059b08326a6f2c29b41aa3d96