### PR TITLE
Fix collapsing when form sections have untouched errors

### DIFF
--- a/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
+++ b/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
@@ -262,7 +262,7 @@ export class FormularioSolicitudComponent implements OnInit {
   }
 
   toggleMenor(): void {
-    if (this.tieneErroresMenor()) {
+    if (this.submitAttempted && this.tieneErroresMenor()) {
       this.datosMenorVisible = true;
       return;
     }
@@ -273,7 +273,7 @@ export class FormularioSolicitudComponent implements OnInit {
   }
 
   togglePadre(): void {
-    if (this.tieneErroresPadre()) {
+    if (this.submitAttempted && this.tieneErroresPadre()) {
       this.datosPadreVisible = true;
       return;
     }
@@ -284,7 +284,7 @@ export class FormularioSolicitudComponent implements OnInit {
   }
 
   toggleViaje(): void {
-    if (this.tieneErroresViaje()) {
+    if (this.submitAttempted && this.tieneErroresViaje()) {
       this.datosViajeVisible = true;
       return;
     }
@@ -295,7 +295,7 @@ export class FormularioSolicitudComponent implements OnInit {
   }
 
   toggleDocumentos(): void {
-    if (this.tieneErroresDocumentos()) {
+    if (this.submitAttempted && this.tieneErroresDocumentos()) {
       this.datosDocumentosVisible = true;
       return;
     }


### PR DESCRIPTION
## Summary
- change toggle logic to only block collapsing sections after a submit attempt

## Testing
- `npm test --silent --unsafe-perm --if-present --prefer-offline` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454340cd208326b0bdb6440b135680