### PR TITLE
Fix error message visibility on form

### DIFF
--- a/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
+++ b/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
@@ -537,7 +537,7 @@
   >
     Cancelar
   </button>
-  <div *ngIf="formulario.invalid" class="text-danger mt-2">
+  <div *ngIf="formulario.touched && formulario.invalid" class="text-danger mt-2">
     Hay errores en el formulario, por favor revisa los campos.
   </div>
 </form>


### PR DESCRIPTION
## Summary
- show global form error only after the form is touched

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845461d6b0c832682af563ee57e250d